### PR TITLE
Кнопочное исправление

### DIFF
--- a/code/_onclick/hud/action_button.dm
+++ b/code/_onclick/hud/action_button.dm
@@ -213,7 +213,8 @@
  */
 /mob/proc/hide_other_mob_action_buttons(mob/take_from)
 	for(var/datum/action/action as anything in take_from.actions)
-		action.HideFrom(src)
+		if(action.owner != take_from)
+			action.HideFrom(src)
 	UnregisterSignal(take_from, list(COMSIG_MOB_GRANTED_ACTION, COMSIG_MOB_REMOVED_ACTION))
 
 /// Signal proc for [COMSIG_MOB_GRANTED_ACTION] - If we're viewing another mob's action buttons,

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -985,6 +985,7 @@ GLOBAL_LIST_INIT(ghost_orbits, list(GHOST_ORBIT_CIRCLE,GHOST_ORBIT_TRIANGLE,GHOS
 		if(ismob(client.eye) && (client.eye != src))
 			var/mob/target = client.eye
 			observetarget = null
+			hide_other_mob_action_buttons(src)
 			if(target.observers)
 				target.observers -= src
 				UNSETEMPTY(target.observers)
@@ -1025,7 +1026,7 @@ GLOBAL_LIST_INIT(ghost_orbits, list(GHOST_ORBIT_CIRCLE,GHOST_ORBIT_TRIANGLE,GHOS
 		return
 
 	//Istype so we filter out points of interest that are not mobs
-	if(client && mob_eye && istype(mob_eye))
+	if(client && mob_eye && istype(mob_eye) && src != mob_eye)
 		client.set_eye(mob_eye)
 		if(mob_eye.hud_used)
 			client.screen = list()


### PR DESCRIPTION
## About The Pull Request
Теперь при смене цели наблюдения, скрываются абилки которые не принадлежат наблюдателю
## Changelog
:cl:
fix: Исправлено наслоение абилок при смене цели наблюдения
fix: Исправлена ошибка при которой наблюдатель мог использовать абилки, которые ему не принадлижат
/:cl: